### PR TITLE
Relax Faraday & Faraday::Middleware requirements

### DIFF
--- a/help_scout-sdk.gemspec
+++ b/help_scout-sdk.gemspec
@@ -12,12 +12,12 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Ruby Help Scout SDK'
   spec.description   = 'Ruby Help Scout SDK.'
-  spec.homepage      = 'https://github.com/taxjar/help-scout-sdk'
+  spec.homepage      = 'https://github.com/taxjar/help_scout-sdk'
   spec.license       = 'MIT'
 
   if spec.respond_to?(:metadata)
-    spec.metadata['source_code_uri'] = 'https://github.com/taxjar/help-scout-sdk'
-    spec.metadata['bug_tracker_uri'] = 'https://github.com/taxjar/help-scout-sdk/issues'
+    spec.metadata['source_code_uri'] = 'https://github.com/taxjar/help_scout-sdk'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/taxjar/help_scout-sdk/issues'
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \
       'public gem pushes.'

--- a/help_scout-sdk.gemspec
+++ b/help_scout-sdk.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'faraday', '~> 0.14'
+  spec.add_dependency 'faraday', '~> 0.10'
   spec.add_dependency 'faraday_middleware', '~> 0.12'
   spec.required_ruby_version = '>= 2.3'
 

--- a/help_scout-sdk.gemspec
+++ b/help_scout-sdk.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'faraday', '~> 0.10'
-  spec.add_dependency 'faraday_middleware', '~> 0.12'
+  spec.add_dependency 'faraday_middleware', '>= 0.10.1', '< 1.0'
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency 'awesome_print', '~> 1.8'


### PR DESCRIPTION
We should relax the `Faraday` and `Faraday::Middleware` requirements for improved compatibility. 

I didn't notice anything in either of the release logs ([`Faraday`](https://github.com/lostisland/faraday/releases?before=0.10.0) and [`Faraday::Middleware`](https://github.com/lostisland/faraday_middleware/releases?before=0.10.1)) that would be a cause for concern. 

I've cherry-picked these changes into my [Mailbox API 2.0 branch](https://github.com/taxjar/helpscout/pull/2) and installed the lowest allowed version of each (0.10.0 and 0.10.1 respectively) to be sure that at a minimum specs still pass.

I think this is a pretty conservative "expansion" of allowable versions and that we're better off being more permissive unless we have a specific reason not to.

Do you think we should bump the version to `1.0.0.pre` just to be safe if people are installing from git?

/cc @andremleblanc @jcypret 