### PR TITLE
Add new functionality to HelpScout::Threads (create, update, get)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+### master (unreleased)
+
+Enhancements:
+
+* Adds support for `HelpScout::Thread.create`, `HelpScout::Thread.get`, and
+  `HelpScout::Thread#update` (Justin White, [#13](https://github.com/taxjar/help_scout-sdk/pull/13))
+
+### 1.1.0 / 2019-06-20
+
+### 1.0.2 / 2019-06-07
+
+### 1.0.1 / 2019-06-07
+
+### 1.0.0 / 2019-06-05
+
+Breaking Changes:
+
+* Drops support for the Mailbox 1.0 API ([#2](https://github.com/taxjar/help_scout-sdk/pull/2))
+
+Enhancements:
+
+* Updated to support the Mailbox 2.0 API ([#2](https://github.com/taxjar/help_scout-sdk/pull/2))

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ And then execute:
 | :------------------------- | :--: | :--: | :-----: | :----: | :-----: |
 | Attachment                 |   ❌  |  ❌  |    ✅   |    ❌   |    ❌   |
 | Conversations              |   ✅  |  ✅  |    ✅   |    ✅   |    ❌   |
-| Conversation::Threads      |   ❌  |  ❌  |    ❌   |    ❌   |    ❌   |
-| Conversation::ThreadSource |   ❌  |  ❌  |    ❌   |    ❌   |    ❌   |
+| Conversation::Threads      |   ✅  |  ➖  |    ✅   |    ✅   |    ➖   |
 | Customers                  |   ✅  |  ✅  |    ❌   |    ❌   |    ❌   |
 | Notes                      |   ❌  |  ❌  |    ❌   |    ❌   |    ❌   |
 | Mailboxes                  |   ✅  |  ✅  |    ➖   |    ➖   |    ➖   |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ mailbox.fields
 mailbox.folders
 ```
 
+### Threads
+
+[Documentation Link](https://developer.helpscout.com/mailbox-api/endpoints/conversations/threads/list/)
+
+```ruby
+conversation = HelpScout::Conversation.list.first
+new_thread = HelpScout::Thread.create(conversation.id, "notes", { text: 'Hello, world!' })
+threads = HelpScout::Thread.list(conversation.id)
+latest_thread = threads.first
+latest_thread.update("replace", "/text", "Updating a threads text.")
+modified_thread = HelpScout::Thread.get(conversation.id, latest_thread.id)
+```
+
 ### Users
 
 [Documentation Link](https://developer.helpscout.com/mailbox-api/endpoints/users/list/)

--- a/lib/help_scout/thread.rb
+++ b/lib/help_scout/thread.rb
@@ -8,6 +8,7 @@ module HelpScout
           create_path(conversation_id, thread_type),
           HelpScout::Util.camelize_keys(params)
         )
+        true
       end
 
       def list(conversation_id, page: nil)

--- a/lib/help_scout/thread.rb
+++ b/lib/help_scout/thread.rb
@@ -19,6 +19,8 @@ module HelpScout
 
       def get(conversation_id, thread_id)
         threads = list(conversation_id)
+        thread_id = thread_id.to_i
+
         threads.find { |thread| thread.id == thread_id }
       end
 

--- a/lib/help_scout/thread.rb
+++ b/lib/help_scout/thread.rb
@@ -4,11 +4,16 @@ module HelpScout
   class Thread < HelpScout::Base
     class << self
       def create(conversation_id, thread_type, params)
-        HelpScout.api.post(create_path(conversation_id, thread_type), HelpScout::Util.camelize_keys(params))
+        HelpScout.api.post(
+          create_path(conversation_id, thread_type),
+          HelpScout::Util.camelize_keys(params)
+        )
       end
 
       def list(conversation_id, page: nil)
-        HelpScout.api.get(list_path(conversation_id), page: page).embedded_list.map { |details| new (details.merge({conversation_id: conversation_id})) }
+        HelpScout.api.get(
+          list_path(conversation_id), page: page
+        ).embedded_list.map { |details| new details.merge(conversation_id: conversation_id) }
       end
 
       def get(conversation_id, thread_id)

--- a/lib/help_scout/thread.rb
+++ b/lib/help_scout/thread.rb
@@ -3,11 +3,24 @@
 module HelpScout
   class Thread < HelpScout::Base
     class << self
+      def create(conversation_id, thread_type, params)
+        HelpScout.api.post(create_path(conversation_id, thread_type), HelpScout::Util.camelize_keys(params))
+      end
+
       def list(conversation_id, page: nil)
-        HelpScout.api.get(list_path(conversation_id), page: page).embedded_list.map { |details| new details }
+        HelpScout.api.get(list_path(conversation_id), page: page).embedded_list.map { |details| new (details.merge({conversation_id: conversation_id})) }
+      end
+
+      def get(conversation_id, thread_id)
+        threads = list(conversation_id)
+        threads.find { |thread| thread.id == thread_id }
       end
 
       private
+
+      def create_path(conversation_id, thread_type)
+        "conversations/#{conversation_id}/#{thread_type}"
+      end
 
       def list_path(conversation_id)
         "conversations/#{conversation_id}/threads"
@@ -32,6 +45,7 @@ module HelpScout
       created_at
       opened_at
       attachments
+      conversation_id
     ].freeze
 
     attr_accessor(*BASIC_ATTRIBUTES)
@@ -45,6 +59,16 @@ module HelpScout
       end
 
       @hrefs = HelpScout::Util.map_links(params.fetch(:_links, []))
+    end
+
+    def conversation
+      @_conversation ||= HelpScout::Conversation.get(conversation_id)
+    end
+
+    def update(operation, path, value = nil)
+      update_path = "conversations/#{conversation_id}/threads/#{id}"
+      HelpScout.api.patch(update_path, op: operation, path: path, value: value)
+      true
     end
   end
 end

--- a/spec/cassettes/HelpScout_Thread/_create/creates_a_new_thread_on_a_given_conversation.yml
+++ b/spec/cassettes/HelpScout_Thread/_create/creates_a_new_thread_on_a_given_conversation.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helpscout.net/v2/oauth2/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"client_credentials","client_id":"<HELP_SCOUT_APP_ID>","client_secret":"<HELP_SCOUT_APP_SECRET>"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jul 2019 19:19:31 GMT
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '92'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"bearer","access_token":"<HELP_SCOUT_ACCESS_TOKEN>","expires_in":7200}
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jul 2019 19:19:31 GMT
+- request:
+    method: post
+    uri: https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/notes
+    body:
+      encoding: UTF-8
+      string: '{"text":"Hello, note!"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Authorization:
+      - Bearer <HELP_SCOUT_ACCESS_TOKEN>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Correlation-Id:
+      - d48eb0d4-12dd-4181-9b4b-75d29145fd98#113193500
+      Date:
+      - Tue, 16 Jul 2019 19:19:31 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Ratelimit-Limit-Minute:
+      - '400'
+      X-Ratelimit-Remaining-Minute:
+      - '398'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 16 Jul 2019 19:19:32 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/HelpScout_Thread/_get/returns_a_HelpScout_Thread_given_a_conversation_id_and_thread_id.yml
+++ b/spec/cassettes/HelpScout_Thread/_get/returns_a_HelpScout_Thread_given_a_conversation_id_and_thread_id.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helpscout.net/v2/oauth2/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"client_credentials","client_id":"<HELP_SCOUT_APP_ID>","client_secret":"<HELP_SCOUT_APP_SECRET>"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jul 2019 19:22:22 GMT
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '92'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"bearer","access_token":"<HELP_SCOUT_ACCESS_TOKEN>","expires_in":7200}
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jul 2019 19:22:22 GMT
+- request:
+    method: get
+    uri: https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Authorization:
+      - Bearer <HELP_SCOUT_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/hal+json;charset=UTF-8
+      Correlation-Id:
+      - 99666b7a-fe2c-4f66-84bf-37a43d9b15d7#62331416
+      Date:
+      - Tue, 16 Jul 2019 19:22:22 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Ratelimit-Limit-Minute:
+      - '400'
+      X-Ratelimit-Remaining-Minute:
+      - '396'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '5975'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"_embedded":{"threads":[{"id":2535529292,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-16T19:19:32Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2535524362,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-16T19:17:39Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2535517559,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-16T19:15:11Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2519189245,"type":"message","status":"active","state":"published","action":{"type":"original-author"},"body":"Sounds
+        good!<br />","source":{"type":"web","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"savedReplyId":0,"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-09T18:40:17Z","openedAt":"2019-07-09T18:40:44Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2519165247,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-09T18:31:21Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":<TEST_THREAD_ID>,"type":"customer","status":"active","state":"published","action":{"type":"default"},"body":"This
+        is a dummy thread.","source":{"type":"email","via":"customer"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":268319927,"type":"customer","first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"savedReplyId":0,"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-09T18:29:22Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByCustomer":{"href":"https://api.helpscout.net/v2/customers/268319927"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}}]},"_links":{"first":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/?page=1"},"last":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/?page=1"},"page":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/"},"self":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/"}},"page":{"size":25,"totalElements":6,"totalPages":1,"number":1}}'
+    http_version: 
+  recorded_at: Tue, 16 Jul 2019 19:22:22 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/HelpScout_Thread/_update/updates_a_given_thread_s_text_on_a_conversation.yml
+++ b/spec/cassettes/HelpScout_Thread/_update/updates_a_given_thread_s_text_on_a_conversation.yml
@@ -1,0 +1,217 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helpscout.net/v2/oauth2/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"client_credentials","client_id":"<HELP_SCOUT_APP_ID>","client_secret":"<HELP_SCOUT_APP_SECRET>"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jul 2019 19:22:21 GMT
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '92'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"bearer","access_token":"<HELP_SCOUT_ACCESS_TOKEN>","expires_in":7200}
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jul 2019 19:22:21 GMT
+- request:
+    method: get
+    uri: https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Authorization:
+      - Bearer <HELP_SCOUT_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/hal+json;charset=UTF-8
+      Correlation-Id:
+      - 99666b7a-fe2c-4f66-84bf-37a43d9b15d7#62331367
+      Date:
+      - Tue, 16 Jul 2019 19:22:21 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Ratelimit-Limit-Minute:
+      - '400'
+      X-Ratelimit-Remaining-Minute:
+      - '399'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '5975'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"_embedded":{"threads":[{"id":2535529292,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-16T19:19:32Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2535524362,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-16T19:17:39Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2535517559,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-16T19:15:11Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2519189245,"type":"message","status":"active","state":"published","action":{"type":"original-author"},"body":"Sounds
+        good!<br />","source":{"type":"web","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"savedReplyId":0,"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-09T18:40:17Z","openedAt":"2019-07-09T18:40:44Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2519165247,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-09T18:31:21Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":<TEST_THREAD_ID>,"type":"customer","status":"active","state":"published","action":{"type":"default"},"body":".daerht
+        ymmud a si sihT","source":{"type":"email","via":"customer"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":268319927,"type":"customer","first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"savedReplyId":0,"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-09T18:29:22Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByCustomer":{"href":"https://api.helpscout.net/v2/customers/268319927"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}}]},"_links":{"first":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/?page=1"},"last":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/?page=1"},"page":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/"},"self":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/"}},"page":{"size":25,"totalElements":6,"totalPages":1,"number":1}}'
+    http_version: 
+  recorded_at: Tue, 16 Jul 2019 19:22:21 GMT
+- request:
+    method: patch
+    uri: https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/<TEST_THREAD_ID>
+    body:
+      encoding: UTF-8
+      string: '{"op":"replace","path":"/text","value":"This is a dummy thread."}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Authorization:
+      - Bearer <HELP_SCOUT_ACCESS_TOKEN>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Correlation-Id:
+      - ec159308-58f3-42b7-827a-2788227a7d8c#91975436
+      Date:
+      - Tue, 16 Jul 2019 19:22:21 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Ratelimit-Limit-Minute:
+      - '400'
+      X-Ratelimit-Remaining-Minute:
+      - '398'
+      X-Xss-Protection:
+      - 1; mode=block
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 16 Jul 2019 19:22:21 GMT
+- request:
+    method: get
+    uri: https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Authorization:
+      - Bearer <HELP_SCOUT_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/hal+json;charset=UTF-8
+      Correlation-Id:
+      - ec159308-58f3-42b7-827a-2788227a7d8c#91975441
+      Date:
+      - Tue, 16 Jul 2019 19:22:22 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Ratelimit-Limit-Minute:
+      - '400'
+      X-Ratelimit-Remaining-Minute:
+      - '397'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"_embedded":{"threads":[{"id":2535529292,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-16T19:19:32Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2535524362,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-16T19:17:39Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2535517559,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-16T19:15:11Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2519189245,"type":"message","status":"active","state":"published","action":{"type":"original-author"},"body":"Sounds
+        good!<br />","source":{"type":"web","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"savedReplyId":0,"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-09T18:40:17Z","openedAt":"2019-07-09T18:40:44Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":2519165247,"type":"note","status":"active","state":"published","action":{"type":"default"},"body":"Hello,
+        note!","source":{"type":"api","via":"user"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":378608,"type":"user","first":"Paul","last":"Simpson","email":"paul@simpsonconsulting.ltd"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-09T18:31:21Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByUser":{"href":"https://api.helpscout.net/v2/users/378608"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}},{"id":<TEST_THREAD_ID>,"type":"customer","status":"active","state":"published","action":{"type":"default"},"body":"This
+        is a dummy thread.","source":{"type":"email","via":"customer"},"customer":{"id":268319927,"first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"createdBy":{"id":268319927,"type":"customer","first":"Paul","last":"Simpson","photoUrl":"https://img.fullcontact.com/static/664fc3306cc6eb7ce5b55611d0ebcc42_6f8d7e4a9b7e4fd8726bca36132bf21572a5238b93e89d79dd63d3a55da7fcc8","email":"paul@taxjar.com"},"assignedTo":{"id":1,"first":"Help","last":"Scout","email":"none@nowhere.com"},"savedReplyId":0,"to":[],"cc":[],"bcc":[],"createdAt":"2019-07-09T18:29:22Z","_embedded":{"attachments":[]},"_links":{"assignedTo":{"href":"https://api.helpscout.net/v2/users/1"},"createdByCustomer":{"href":"https://api.helpscout.net/v2/customers/268319927"},"customer":{"href":"https://api.helpscout.net/v2/customers/268319927"}}}]},"_links":{"first":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/?page=1"},"last":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/?page=1"},"page":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/"},"self":{"href":"https://api.helpscout.net/v2/conversations/<TEST_CONVERSATION_ID>/threads/"}},"page":{"size":25,"totalElements":6,"totalPages":1,"number":1}}'
+    http_version: 
+  recorded_at: Tue, 16 Jul 2019 19:22:22 GMT
+recorded_with: VCR 5.0.0

--- a/spec/integration/thread_spec.rb
+++ b/spec/integration/thread_spec.rb
@@ -2,6 +2,15 @@
 
 RSpec.describe HelpScout::Thread do
   let(:conversation_id) { ENV.fetch('TEST_CONVERSATION_ID') }
+  let(:thread_id) { ENV.fetch('TEST_THREAD_ID')}
+
+  describe '.get' do 
+    it "returns a HelpScout::Thread given a conversation_id and thread_id" do 
+      thread = described_class.get(conversation_id, thread_id)
+
+      expect(thread).to be_a(described_class)
+    end
+  end
 
   describe '.list' do
     subject { described_class.list(conversation_id) }
@@ -9,6 +18,36 @@ RSpec.describe HelpScout::Thread do
     it "returns an Array of #{described_class} objects" do
       expect(subject).to be_a Array
       expect(subject).to all(be_a(described_class))
+    end
+  end
+
+  describe '.create' do
+    subject { described_class.create(conversation_id, thread_type, params)}
+    let(:thread_type) { "notes" }
+    let(:params) do
+      {
+        text: "Hello, note!"
+      }
+    end
+
+    it 'creates a new thread on a given conversation' do
+      expect(subject.success?).to eq(true)
+    end
+  end
+
+  describe '#update' do
+    it "updates a given thread's text on a conversation" do
+      thread = described_class.get(conversation_id, thread_id) 
+      original_body = thread.body
+      update_params = {
+        op: 'replace',
+        path: '/text',
+        value: original_body.reverse
+      }
+
+      expect(thread.update(*update_params.values)).to be true
+      new_body = described_class.get(conversation_id, thread_id).body
+      expect(new_body).to eq(update_params[:value])
     end
   end
 end

--- a/spec/integration/thread_spec.rb
+++ b/spec/integration/thread_spec.rb
@@ -2,10 +2,10 @@
 
 RSpec.describe HelpScout::Thread do
   let(:conversation_id) { ENV.fetch('TEST_CONVERSATION_ID') }
-  let(:thread_id) { ENV.fetch('TEST_THREAD_ID')}
+  let(:thread_id) { ENV.fetch('TEST_THREAD_ID') }
 
-  describe '.get' do 
-    it "returns a HelpScout::Thread given a conversation_id and thread_id" do 
+  describe '.get' do
+    it "returns a #{described_class} given a conversation_id and thread_id" do
       thread = described_class.get(conversation_id, thread_id)
 
       expect(thread).to be_a(described_class)
@@ -22,11 +22,11 @@ RSpec.describe HelpScout::Thread do
   end
 
   describe '.create' do
-    subject { described_class.create(conversation_id, thread_type, params)}
-    let(:thread_type) { "notes" }
+    subject { described_class.create(conversation_id, thread_type, params) }
+    let(:thread_type) { 'notes' }
     let(:params) do
       {
-        text: "Hello, note!"
+        text: 'Hello, note!'
       }
     end
 
@@ -37,7 +37,7 @@ RSpec.describe HelpScout::Thread do
 
   describe '#update' do
     it "updates a given thread's text on a conversation" do
-      thread = described_class.get(conversation_id, thread_id) 
+      thread = described_class.get(conversation_id, thread_id)
       original_body = thread.body
       update_params = {
         op: 'replace',

--- a/spec/integration/thread_spec.rb
+++ b/spec/integration/thread_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe HelpScout::Thread do
     end
 
     it 'creates a new thread on a given conversation' do
-      expect(subject.success?).to eq(true)
+      expect(subject).to eq(true)
     end
   end
 


### PR DESCRIPTION
This adds functionality to create and update a thread via the API. It also attempts to provide a "get" functionality, despite the HelpScout 2.0 API not supporting such an endpoint. It also update the README to reflect the API functionality lacking for a true GET and DELETE for Threads.