### PR TITLE
Removes Configuration#access_token to avoid stale/duplicate tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+### master (unreleased)
+
+Breaking Changes:
+
+* Removes HelpScout::Configuration#access_token and writer to avoid multiple sources
+  of truth for access token values (#14)
+
+### 1.1.0 / 2019-06-20
+
+### 1.0.2 / 2019-06-07
+
+### 1.0.1 / 2019-06-07
+
+### 1.0.0 / 2019-06-05
+
+Breaking Changes:
+
+* Drops support for the Mailbox 1.0 API
+
+Enhancements:
+
+* Updated to support the Mailbox 2.0 API

--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ And then execute:
 HelpScout.configure do |config|
   config.app_id = ENV["HELP_SCOUT_APP_ID"]
   config.app_secret = ENV["HELP_SCOUT_APP_SECRET"]
-
-  config.access_token = HelpScout::API::AccessToken.create
 end
 ```
 

--- a/bin/console
+++ b/bin/console
@@ -11,7 +11,6 @@ HelpScout.configure do |config|
   config.app_id = ENV.fetch('HELP_SCOUT_APP_ID')
   config.app_secret = ENV.fetch('HELP_SCOUT_APP_SECRET')
   config.default_mailbox = ENV.fetch('HELP_SCOUT_DEFAULT_MAILBOX')
-  config.access_token = ENV.fetch('HELP_SCOUT_ACCESS_TOKEN', nil)
 end
 
 begin

--- a/lib/help_scout-sdk.rb
+++ b/lib/help_scout-sdk.rb
@@ -52,7 +52,6 @@ module HelpScout
 
     def configure
       yield(configuration)
-      api.access_token = HelpScout.configuration.access_token
     end
 
     def default_mailbox

--- a/lib/help_scout/api/access_token.rb
+++ b/lib/help_scout/api/access_token.rb
@@ -16,7 +16,7 @@ module HelpScout
         end
 
         def refresh!
-          return HelpScout.api.access_token unless HelpScout.access_token.nil? || HelpScout.access_token.stale?
+          return HelpScout.access_token unless HelpScout.access_token.nil? || HelpScout.access_token.stale?
 
           HelpScout.api.access_token = create
         end

--- a/lib/help_scout/configuration.rb
+++ b/lib/help_scout/configuration.rb
@@ -3,16 +3,9 @@
 module HelpScout
   class Configuration
     attr_accessor :app_id, :app_secret, :default_mailbox, :token_cache
-    attr_reader :access_token
     attr_writer :token_cache_key
 
     DEFAULT_CACHE_KEY = 'help_scout_token_cache'
-
-    def access_token=(token_value)
-      return unless token_value
-
-      @access_token = HelpScout::API::AccessToken.new(access_token: token_value)
-    end
 
     def token_cache_key
       return @token_cache_key if defined?(@token_cache_key)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,9 +55,9 @@ end
 HelpScout.configure do |config|
   config.app_id = ENV.fetch('HELP_SCOUT_APP_ID')
   config.app_secret = ENV.fetch('HELP_SCOUT_APP_SECRET')
-  config.access_token = ENV.fetch('HELP_SCOUT_ACCESS_TOKEN', nil)
   config.default_mailbox = ENV.fetch('TEST_MAILBOX_ID')
 end
+HelpScout.api.access_token = ENV.fetch('HELP_SCOUT_ACCESS_TOKEN', 'bogustoken')
 
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/cassettes'


### PR DESCRIPTION
Rather than allowing the access token to be set via `Configuration`, we'll always either grab it from the cache (if configured) or generate a new token from the Help Scout API. This also prevents the situation where the configuration instance and the api instance have "competing" tokens.

We can still manually set the token for testing purposes via `HelpScout.api.access_token=`.

Resolves #12 