### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ### master (unreleased)
 
+### 2.0.0 / 2019-07-19
+
 Breaking Changes:
 
 * Removes HelpScout::Configuration#access_token and writer to avoid multiple sources
-  of truth for access token values (#14)
+  of truth for access token values ([#14](https://github.com/taxjar/help_scout-sdk/pull/14))
 
 Enhancements:
 

--- a/lib/help_scout/version.rb
+++ b/lib/help_scout/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HelpScout
-  VERSION = '1.1.0'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
~~Note: currently targeting `remove-access-token-config` until #14 is merged.~~

This bumps the version and updates the CHANGELOG for the 2.0.0 release.