### PR TITLE
Support for querying customers and updating their emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Breaking Changes:
   However, Faraday does not support Ruby 2.x on this version.
     ([#30](https://github.com/taxjar/help_scout-sdk/pull/30))
 
+### 2.0.1 / 2020-12-15
+
+Enhancements:
+
+* Adds support for passing params to `list` requests (Jorge Manrubia, [#19](https://github.com/taxjar/help_scout-sdk/pull/19))
+* Adds support for updating customer emails (Jorge Manrubia, [#19](https://github.com/taxjar/help_scout-sdk/pull/19)) 
+
 ### 2.0.0 / 2019-07-19
 
 Breaking Changes:

--- a/lib/help_scout/customer.rb
+++ b/lib/help_scout/customer.rb
@@ -47,5 +47,11 @@ module HelpScout
 
       @hrefs = HelpScout::Util.map_links(params[:_links])
     end
+
+    def update_email(email_id, new_email, type: :other)
+      email_path = "#{URI.parse(hrefs[:self]).path}/emails/#{email_id}"
+      HelpScout.api.put(email_path, { type: type, value: new_email })
+      true
+    end
   end
 end

--- a/lib/help_scout/modules/listable.rb
+++ b/lib/help_scout/modules/listable.rb
@@ -2,8 +2,8 @@
 
 module HelpScout
   module Listable
-    def list(id: HelpScout.default_mailbox, page: nil)
-      HelpScout.api.get(list_path(id), page: page).embedded_list.map { |e| new e }
+    def list(id: HelpScout.default_mailbox, page: nil, **params)
+      HelpScout.api.get(list_path(id), { page: page }.merge(params)).embedded_list.map { |e| new e }
     end
 
     def list_path(_)
@@ -11,3 +11,4 @@ module HelpScout
     end
   end
 end
+

--- a/spec/cassettes/HelpScout_Customer/_update_email/updates_the_customer_email.yml
+++ b/spec/cassettes/HelpScout_Customer/_update_email/updates_the_customer_email.yml
@@ -1,0 +1,229 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helpscout.net/v2/oauth2/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"client_credentials","client_id":"<HELP_SCOUT_APP_ID>","client_secret":"<HELP_SCOUT_APP_SECRET>"}'
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location,Resource-Id
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 15 Dec 2020 09:45:05 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - kong/0.14.1
+      Content-Length:
+      - '94'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"bearer","access_token":"<HELP_SCOUT_ACCESS_TOKEN>","expires_in":172800}
+
+        '
+    http_version:
+  recorded_at: Tue, 15 Dec 2020 09:45:05 GMT
+- request:
+    method: get
+    uri: https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Authorization:
+      - Bearer <HELP_SCOUT_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location,Resource-Id
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/hal+json
+      Correlation-Id:
+      - 03efcba5-bbcf-4451-bb12-3f20c38e36f3#38131666
+      Date:
+      - Tue, 15 Dec 2020 09:45:41 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Via:
+      - kong/0.14.1
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Kong-Proxy-Latency:
+      - '3'
+      X-Kong-Upstream-Latency:
+      - '54'
+      X-Ratelimit-Limit-Minute:
+      - '400'
+      X-Ratelimit-Remaining-Minute:
+      - '397'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":<TEST_CUSTOMER_ID>,"firstName":"","lastName":"","gender":"Unknown","photoType":"default","photoUrl":"https://d33v4339jhl8k0.cloudfront.net/customer-avatar/08.png","createdAt":"2020-06-18T14:54:41Z","updatedAt":"2020-12-14T17:38:39Z","background":"","_embedded":{"emails":[{"id":465697159,"value":"jorge@hey.com","type":"work"}],"phones":[],"chats":[],"social_profiles":[],"websites":[],"properties":[]},"_links":{"address":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/address/"},"chats":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/chats/"},"emails":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/emails/"},"phones":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/phones/"},"social-profiles":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/social-profiles/"},"websites":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/websites/"},"self":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>"}}}'
+    http_version:
+  recorded_at: Tue, 15 Dec 2020 09:45:41 GMT
+- request:
+    method: put
+    uri: https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/emails/465697159
+    body:
+      encoding: UTF-8
+      string: '{"type":"work","value":"changedjorge@hey.com"}'
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Authorization:
+      - Bearer <HELP_SCOUT_ACCESS_TOKEN>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location,Resource-Id
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Correlation-Id:
+      - f883891e-f70b-47af-879f-a89cc774103a#33293114
+      Date:
+      - Tue, 15 Dec 2020 09:45:41 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Via:
+      - kong/0.14.1
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Kong-Proxy-Latency:
+      - '4'
+      X-Kong-Upstream-Latency:
+      - '202'
+      X-Ratelimit-Limit-Minute:
+      - '400'
+      X-Ratelimit-Remaining-Minute:
+      - '395'
+      X-Xss-Protection:
+      - 1; mode=block
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version:
+  recorded_at: Tue, 15 Dec 2020 09:45:41 GMT
+- request:
+    method: get
+    uri: https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Authorization:
+      - Bearer <HELP_SCOUT_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location,Resource-Id
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/hal+json
+      Correlation-Id:
+      - f883891e-f70b-47af-879f-a89cc774103a#33293118
+      Date:
+      - Tue, 15 Dec 2020 09:45:42 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Via:
+      - kong/0.14.1
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Kong-Proxy-Latency:
+      - '3'
+      X-Kong-Upstream-Latency:
+      - '50'
+      X-Ratelimit-Limit-Minute:
+      - '400'
+      X-Ratelimit-Remaining-Minute:
+      - '394'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":<TEST_CUSTOMER_ID>,"firstName":"","lastName":"","gender":"Unknown","photoType":"default","photoUrl":"https://d33v4339jhl8k0.cloudfront.net/customer-avatar/08.png","createdAt":"2020-06-18T14:54:41Z","updatedAt":"2020-12-14T17:38:39Z","background":"","_embedded":{"emails":[{"id":465697159,"value":"changedjorge@hey.com","type":"work"}],"phones":[],"chats":[],"social_profiles":[],"websites":[],"properties":[]},"_links":{"address":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/address/"},"chats":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/chats/"},"emails":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/emails/"},"phones":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/phones/"},"social-profiles":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/social-profiles/"},"websites":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>/websites/"},"self":{"href":"https://api.helpscout.net/v2/customers/<TEST_CUSTOMER_ID>"}}}'
+    http_version:
+  recorded_at: Tue, 15 Dec 2020 09:45:42 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/HelpScout_Customer/list/finds_customers_filtered_with_query.yml
+++ b/spec/cassettes/HelpScout_Customer/list/finds_customers_filtered_with_query.yml
@@ -1,0 +1,109 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helpscout.net/v2/oauth2/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"client_credentials","client_id":"<HELP_SCOUT_APP_ID>","client_secret":"<HELP_SCOUT_APP_SECRET>"}'
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location,Resource-Id
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 15 Dec 2020 10:53:49 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - kong/0.14.1
+      Content-Length:
+      - '94'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"bearer","access_token":"<HELP_SCOUT_ACCESS_TOKEN>","expires_in":172800}
+
+        '
+    http_version:
+  recorded_at: Tue, 15 Dec 2020 10:53:49 GMT
+- request:
+    method: get
+    uri: https://api.helpscout.net/v2/customers?query=(email:%22some.anonymous.123456@email.com%22)
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Authorization:
+      - Bearer <HELP_SCOUT_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location,Resource-Id
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/hal+json
+      Correlation-Id:
+      - d48066af-6189-4c30-952e-1f640af4530a#37772310
+      Date:
+      - Tue, 15 Dec 2020 10:53:49 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Via:
+      - kong/0.14.1
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Kong-Proxy-Latency:
+      - '4'
+      X-Kong-Upstream-Latency:
+      - '164'
+      X-Ratelimit-Limit-Minute:
+      - '400'
+      X-Ratelimit-Remaining-Minute:
+      - '390'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '571'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"_embedded":{"customers":[]},"_links":{"self":{"href":"https://api.helpscout.net/v2/customers?query=(email:\"some.anonymous.123456@email.com\")"},"first":{"href":"https://api.helpscout.net/v2/customers?query=(email:\"some.anonymous.123456@email.com\")&page=1"},"last":{"href":"https://api.helpscout.net/v2/customers?query=(email:\"some.anonymous.123456@email.com\")&page=1"},"page":{"href":"https://api.helpscout.net/v2/customers?query=(email:\"some.anonymous.123456@email.com\"){&page}","templated":true}},"page":{"size":50,"totalElements":0,"totalPages":0,"number":1}}'
+    http_version:
+  recorded_at: Tue, 15 Dec 2020 10:53:49 GMT
+recorded_with: VCR 5.1.0

--- a/spec/integration/customer_spec.rb
+++ b/spec/integration/customer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe HelpScout::Customer do
 
   describe 'list' do
     it 'finds customers filtered with query' do
-      result = described_class.list(query: '(email="some@email.com")')
+      result = described_class.list(query: '(email:"some.anonymous.123456@email.com")')
 
       expect(result).to be_a Array
       expect(result).to all(be_a(described_class))

--- a/spec/integration/customer_spec.rb
+++ b/spec/integration/customer_spec.rb
@@ -10,10 +10,22 @@ RSpec.describe HelpScout::Customer do
   include_examples 'listable integration'
 
   describe 'list' do
-    it "finds customers filtered with query" do
+    it 'finds customers filtered with query' do
       result = described_class.list(query: '(email="some@email.com")')
+
       expect(result).to be_a Array
       expect(result).to all(be_a(described_class))
+    end
+  end
+
+  describe '#update_email' do
+    it 'updates the customer email' do
+      customer = described_class.get(id)
+      original_email = customer.emails.first
+      new_email = "changed#{original_email[:value]}"
+
+      expect(customer.update_email(original_email[:id], new_email, type: original_email[:type])).to be_truthy
+      expect(described_class.get(id).emails.first[:value]).to eq(new_email)
     end
   end
 end

--- a/spec/integration/customer_spec.rb
+++ b/spec/integration/customer_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe HelpScout::Customer do
 
   include_examples 'getable integration'
   include_examples 'listable integration'
+
+  describe 'list' do
+    it "finds customers filtered with query" do
+      result = described_class.list(query: '(email="some@email.com")')
+      expect(result).to be_a Array
+      expect(result).to all(be_a(described_class))
+    end
+  end
 end


### PR DESCRIPTION
This adds supports for two things:

- Passing params for listing operations. I wanted to be able to use `query` params when [finding customers](https://developer.helpscout.com/mailbox-api/endpoints/customers/list/). I think supporting params in general for `list` requests makes sense.

- Support for [customer email updates](https://developer.helpscout.com/mailbox-api/endpoints/customers/emails/update/)

It also includes some changes for making the travis build pass:

- Upgrades `rake` to deal with security advisory CVE-2020-8130 that was making Travis fail.
- Bump rubocop's ruby target version to make it work with version0.93 and make rubocop pass

Thanks for the nice lib!