### PR TITLE
relax faraday and faraday_middleware dependency

### DIFF
--- a/help_scout-sdk.gemspec
+++ b/help_scout-sdk.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'faraday', '~> 0.10'
-  spec.add_dependency 'faraday_middleware', '>= 0.10.1', '< 1.0'
+  spec.add_dependency 'faraday', '>= 0.10', '< 2.0'
+  spec.add_dependency 'faraday_middleware', '>= 0.10.1', '< 2.0'
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency 'awesome_print', '~> 1.8'


### PR DESCRIPTION
This was blocking us from upgrading to `faraday` 1.0