### PR TITLE
bump faraday version

### DIFF
--- a/help_scout-sdk.gemspec
+++ b/help_scout-sdk.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'faraday', '~> 0.10'
+  spec.add_dependency 'faraday', '~> 1.3.0'
   spec.add_dependency 'faraday_middleware', '>= 0.10.1', '< 1.0'
   spec.required_ruby_version = '>= 2.3'
 


### PR DESCRIPTION
* The current version of faraday is not compatible with some of the gems that I am using(twilio and active campaign). 
* I pulled this repo and set up an .env file with some dummy info for the variables. I then ran tests before doing anything. I had 77 examples, 22 failures. I wasn't sure if there was something else I needed to add for those other tests to run or if I needed a sandbox to run them with, but I am not sure how to set one up after looking around. I then bumped the version and re-ran the tests. I got the same results, so basically nothing new is broken. 
* If someone can either let me know how to run the tests locally the rest of the way or if you could, that would be appreciated. 

`.env`
```
HELP_SCOUT_APP_ID: 'asdf'
HELP_SCOUT_APP_SECRET: 'asdf'
TEST_MAILBOX_ID: 'asdf'
```

`Initial error when adding this gem`
```
Resolving dependencies......
Bundler could not find compatible versions for gem "faraday":
  In snapshot (Gemfile.lock):
    faraday (= 1.3.0)

  In Gemfile:
    active_campaign was resolved to 3.0.0, which depends on
      faraday (>= 1.0, < 3.0)

    help_scout-sdk was resolved to 2.0.0, which depends on
      faraday (~> 0.10)

    twilio-ruby was resolved to 5.47.0, which depends on
      faraday (>= 0.9, < 2.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

Failing Tests
```
Finished in 0.76312 seconds (files took 1.34 seconds to load)
77 examples, 22 failures

Failed examples:

rspec ./spec/integration/thread_spec.rb:18 # HelpScout::Thread.list returns an Array of HelpScout::Thread objects
rspec ./spec/integration/thread_spec.rb:39 # HelpScout::Thread#update updates a given thread's text on a conversation
rspec ./spec/integration/thread_spec.rb:33 # HelpScout::Thread.create creates a new thread on a given conversation
rspec ./spec/integration/thread_spec.rb:8 # HelpScout::Thread.get returns a HelpScout::Thread given a conversation_id and thread_id
rspec ./spec/integration/conversation_spec.rb:35 # HelpScout::Conversation.create returns the location of the conversation
rspec ./spec/integration/conversation_spec.rb:41 # HelpScout::Conversation#update updates the conversation's subject
rspec ./spec/integration/conversation_spec.rb:86 # HelpScout::Conversation#update_tags with an empty array clears the conversation's tags
rspec ./spec/integration/conversation_spec.rb:71 # HelpScout::Conversation#update_tags with an array of tags replaces the conversation's tags
rspec ./spec/integration/conversation_spec.rb:100 # HelpScout::Conversation#update_tags with no arguments clears the conversation's tags
rspec ./spec/integration/conversation_spec.rb[1:1:1] # HelpScout::Conversation.get returns a HelpScout::Conversation
rspec ./spec/integration/conversation_spec.rb[1:2:1] # HelpScout::Conversation.list returns an Array of HelpScout::Conversation objects
rspec ./spec/integration/user_spec.rb[1:1:1] # HelpScout::User.get returns a HelpScout::User
rspec ./spec/integration/user_spec.rb[1:2:1] # HelpScout::User.list returns an Array of HelpScout::User objects
rspec ./spec/integration/attachment_spec.rb:21 # HelpScout::Attachment.create creates an attachment on the thread
rspec ./spec/integration/folder_spec.rb:5 # HelpScout::Folder.list returns an Array of HelpScout::Folder objects
rspec ./spec/unit/attachment_spec.rb:27 # HelpScout::Attachment.create returns true
rspec ./spec/integration/mailbox_spec.rb[1:1:1] # HelpScout::Mailbox.get returns a HelpScout::Mailbox
rspec ./spec/integration/mailbox_spec.rb:15 # HelpScout::Mailbox#folders returns an Array of Folders
rspec ./spec/integration/mailbox_spec.rb[1:2:1] # HelpScout::Mailbox.list returns an Array of HelpScout::Mailbox objects
rspec ./spec/unit/thread_spec.rb:24 # HelpScout::Thread.list returns an Array of HelpScout::Thread objects
rspec ./spec/unit/thread_spec.rb:35 # HelpScout::Thread.list when page set gets second page
rspec ./spec/integration/customer_spec.rb[1:1:1] # HelpScout::Customer.get returns a HelpScout::Customer

Randomized with seed 9561

/Users/admin/.rbenv/versions/2.7.2/bin/ruby -I/Users/admin/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rspec-core-3.10.1/lib:/Users/admin/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rspec-support-3.10.2/lib /Users/admin/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```
