### PR TITLE
[TJPLAT-1483] upgrade to faraday 2.9 for Ruby 3.x compatibiity

### DIFF
--- a/help_scout-sdk.gemspec
+++ b/help_scout-sdk.gemspec
@@ -31,8 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'faraday', '1.7.2'
-  spec.add_dependency 'faraday_middleware', '1.1.0'
+  spec.add_dependency 'faraday', '2.9.0'
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency 'awesome_print', '~> 1.8'

--- a/lib/help_scout-sdk.rb
+++ b/lib/help_scout-sdk.rb
@@ -4,7 +4,6 @@ require 'active_support'
 require 'active_support/core_ext'
 require 'json'
 require 'faraday'
-require 'faraday_middleware'
 
 require 'help_scout/version'
 

--- a/lib/help_scout/api/client.rb
+++ b/lib/help_scout/api/client.rb
@@ -13,7 +13,7 @@ module HelpScout
         @_connection ||= build_connection.tap do |conn|
           if authorize?
             HelpScout::API::AccessToken.refresh!
-            conn.authorization(:Bearer, access_token) if access_token
+            conn.request(:authorization, 'Bearer', access_token) if access_token
           end
         end
       end


### PR DESCRIPTION
This is a minor version upgrade to the SDK that upgrades the underlying Faraday version to one compatible with Ruby 3.x.

I will adjust version and tag a new Release for this change since it means it will not be backwards compatible, as it looks like Faraday 2.9 no longer supports Ruby 2.x.

So, it is potentially a breaking change.