### PR TITLE
create v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### master (unreleased)
 
+## 3.0.0 / 2024-03-14
+
+Breaking Changes:
+
+* Upgrades Faraday dependency to 2.9 which makes it compatible with Ruby 3.x
+  However, Faraday does not support Ruby 2.x on this version.
+    ([#30](https://github.com/taxjar/help_scout-sdk/pull/30))
+
 ### 2.0.0 / 2019-07-19
 
 Breaking Changes:

--- a/lib/help_scout/version.rb
+++ b/lib/help_scout/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HelpScout
-  VERSION = '2.0.1'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
This is to create v3.0.0 which supports the change made in PR #30 

This is a major version change as it will require Ruby 3.x or greater as Faraday requires Ruby 3.x or greater.