### PR TITLE
Rl 89 fix faraday yo

### DIFF
--- a/help_scout-sdk.gemspec
+++ b/help_scout-sdk.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'faraday', '~> 0.10'
-  spec.add_dependency 'faraday_middleware', '>= 0.10.1', '< 1.0'
+  spec.add_dependency 'faraday', '>= 0.10', '< 2.0'
+  spec.add_dependency 'faraday_middleware', '>= 0.10.1', '< 2.0'
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency 'awesome_print', '~> 1.8'

--- a/help_scout-sdk.gemspec
+++ b/help_scout-sdk.gemspec
@@ -31,9 +31,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'faraday', '>= 0.10', '< 2.0'
-  spec.add_dependency 'faraday_middleware', '>= 0.10.1', '< 2.0'
-  spec.required_ruby_version = '>= 2.3'
+  spec.add_dependency 'faraday', '>= 2', '< 3'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_development_dependency 'awesome_print', '~> 1.8'
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/help_scout-sdk.gemspec
+++ b/help_scout-sdk.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'dotenv', '~> 2.2'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.70'
   spec.add_development_dependency 'vcr', '~> 5.0'

--- a/lib/help_scout-sdk.rb
+++ b/lib/help_scout-sdk.rb
@@ -4,7 +4,6 @@ require 'active_support'
 require 'active_support/core_ext'
 require 'json'
 require 'faraday'
-require 'faraday_middleware'
 
 require 'help_scout/version'
 

--- a/lib/help_scout/api/client.rb
+++ b/lib/help_scout/api/client.rb
@@ -13,7 +13,7 @@ module HelpScout
         @_connection ||= build_connection.tap do |conn|
           if authorize?
             HelpScout::API::AccessToken.refresh!
-            conn.authorization(:Bearer, access_token) if access_token
+            conn.request :authorization, 'Bearer', access_token if access_token
           end
         end
       end

--- a/spec/unit/api/client_spec.rb
+++ b/spec/unit/api/client_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe HelpScout::API::Client do
+  let(:token_value) { JSON.parse(access_token_json)['access_token'] }
+
+  describe '#connection' do
+    it 'returns a Faraday connection pointed at the API base URL' do
+      conn = described_class.new(authorize: false).connection
+
+      expect(conn).to be_a(Faraday::Connection)
+      expect(conn.url_prefix.to_s).to eq(HelpScout::API::BASE_URL)
+    end
+
+    context 'when authorization is enabled and an access token is available' do
+      it 'sends a Bearer Authorization header on requests' do
+        stub = stub_request(:get, api_path('ping'))
+               .with(headers: { 'Authorization' => "Bearer #{token_value}" })
+               .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+        described_class.new.connection.get('ping')
+
+        expect(stub).to have_been_requested
+      end
+    end
+
+    context 'when authorization is disabled' do
+      it 'does not send an Authorization header' do
+        stub = stub_request(:get, api_path('ping'))
+               .with { |request| !request.headers.key?('Authorization') }
+               .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+        described_class.new(authorize: false).connection.get('ping')
+
+        expect(stub).to have_been_requested
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What is in here:
- Bump the `faraday` runtime dependency from `>= 0.10, < 2.0` to `>= 2, < 3` (resolves to `faraday 2.14.3`).
- Drop the `faraday_middleware` runtime dependency entirely, and remove its `require` in `lib/help_scout-sdk.rb`.
- Replace the removed `Faraday::Connection#authorization` helper in `lib/help_scout/api/client.rb` with the `request :authorization` middleware.
- Bump `required_ruby_version` to `>= 3.0` (Faraday 2.14.3 requires Ruby >= 3.0, so the old `>= 2.3` was inaccurate).
- Add a unit spec for `HelpScout::API::Client`.

## WHAT IS NOT IN HERE:
- Rubocop is so old and decrepit. It wouldn't even run (true on master--egads, I really don't like that anymore), but I did fix it locally. Ran it, and there were 5 issues (on master, too, and unrelated). I could've fixed them, and/or but then, it'd make sense to move rubcop to at least 1.x something, and then that could've meant a whole heck of a lot more, so anyway, I dropped my changes, didn't make any rubocop fixes, because **I don't want nothing exciting happening in this repo**.

~- `bundle-audit` flags `rake 10.x` (CVE-2020-8130) via the untouched dev dependency — also pre-existing.~
**UPDATE**: It was a light lift to solve that, and I figure I may as well remove that security vulnerability while I was here. So now it **IS** in here as a separate commit.

## Why

The main app needs Faraday 2.x, so this fork has to stop pinning `< 2.0`.

Two things make the upgrade nearly drop-in:

- **`faraday_middleware` is gone because we no longer need it.** The `request :json` / `response :json` middleware that used to live in `faraday_middleware` were moved into Faraday core in 2.0. `lib/help_scout/api/client.rb` already calls `conn.request :json` and `conn.response :json` (not the old `faraday_middleware`-namespaced versions), so those lines keep working unchanged once core provides them — the gem dependency and its `require` are now dead weight.

- **The one real code change is the `conn.` line.** Faraday 2.0 removed the `Faraday::Connection#authorization` convenience helper. The old code did:

  `conn.authorization(:Bearer, access_token)`

  Under Faraday 2 that raises `NoMethodError: undefined method 'authorization' for #<Faraday::Connection>`. The supported replacement is to register the authorization request middleware:

  `conn.request :authorization, 'Bearer', access_token`

  Note this is not a like-for-like swap of one header-setter for another. The old helper set a default header on the connection immediately. The new form adds a middleware that injects the `Authorization` header at request time. The net behavior (every request carries `Authorization: Bearer <token>`) is identical, which is what the new spec pins down.

## Testing & coverage

There was no direct unit spec for `HelpScout::API::Client` — the auth path was only exercised transitively through the VCR-backed integration specs. That's a thin safety net here for two reasons: VCR matches on method + URI, **not** headers, so a silently-wrong `Authorization` header would not fail any existing test; and the integration specs would only have caught the hard `NoMethodError`, not a subtly-wrong header.

So I added `spec/unit/api/client_spec.rb` asserting the connection actually sends `Authorization: Bearer <token>` on the wire (via WebMock), plus the no-auth case. It's deliberately implementation-agnostic — it passes whether the header is set as a Faraday 1 default header or via the Faraday 2 middleware — so it locks the observable behavior across the upgrade rather than the mechanism.

Verification performed locally on `faraday 2.14.3`, Ruby 3.2.4:

- Confirmed the new spec **fails** with the unmodified `conn.authorization` line (`NoMethodError`), proving it catches the regression.
- After the `conn.request :authorization` fix: full suite green, 80 examples, 0 failures (77 pre-existing + 3 new).