### PR TITLE
Expose Retry-After on ThrottleLimitReached

### DIFF
--- a/lib/help_scout/api.rb
+++ b/lib/help_scout/api.rb
@@ -6,7 +6,14 @@ module HelpScout
     class NotAuthorized < StandardError; end
     class NotFound < StandardError; end
     class InternalError < StandardError; end
-    class ThrottleLimitReached < StandardError; end
+    class ThrottleLimitReached < StandardError
+      attr_reader :retry_after
+
+      def initialize(message = nil, retry_after: nil)
+        super(message)
+        @retry_after = retry_after
+      end
+    end
 
     BASE_URL = 'https://api.helpscout.net/v2/'
 
@@ -38,10 +45,15 @@ module HelpScout
         when 400 then raise BadRequest, result.body&.dig('validationErrors')
         when 401 then raise NotAuthorized, result.body&.dig('error_description')
         when 404 then raise NotFound, 'Resource Not Found'
-        when 429 then raise ThrottleLimitReached, result.body&.dig('error')
+        when 429 then raise ThrottleLimitReached.new(result.body&.dig('error'), retry_after: retry_after(result))
         else raise InternalError, result.body
         end
       end
+    end
+
+    def retry_after(result)
+      value = result.headers && result.headers['Retry-After']
+      value && Integer(value, exception: false)
     end
 
     def new_connection

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe HelpScout::API do
+  describe '#get' do
+    subject { HelpScout.api.get('mailboxes') }
+
+    context 'when the request is rate limited' do
+      let(:error) { { error: 'Request was throttled' } }
+      let(:headers) { { 'Content-Type' => 'application/json' } }
+
+      before do
+        stub_request(:get, api_path('mailboxes'))
+          .to_return(status: 429, body: error.to_json, headers: headers)
+      end
+
+      it 'raises an API::ThrottleLimitReached error with no retry_after' do
+        expect { subject }.to raise_error(HelpScout::API::ThrottleLimitReached, error[:error]) do |exception|
+          expect(exception.retry_after).to be_nil
+        end
+      end
+
+      context 'when the response includes a Retry-After header' do
+        let(:headers) { { 'Content-Type' => 'application/json', 'Retry-After' => '30' } }
+
+        it 'raises an API::ThrottleLimitReached error with retry_after in seconds' do
+          expect { subject }.to raise_error(HelpScout::API::ThrottleLimitReached, error[:error]) do |exception|
+            expect(exception.retry_after).to eq 30
+          end
+        end
+      end
+
+      context 'when the Retry-After header is malformed' do
+        let(:headers) { { 'Content-Type' => 'application/json', 'Retry-After' => 'later' } }
+
+        it 'raises an API::ThrottleLimitReached error with no retry_after' do
+          expect { subject }.to raise_error(HelpScout::API::ThrottleLimitReached, error[:error]) do |exception|
+            expect(exception.retry_after).to be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Help Scout returns a `Retry-After` header with 429 responses, but `ThrottleLimitReached` discards it, so callers can only guess at a backoff interval.

This carries the header through: `ThrottleLimitReached#retry_after` returns the parsed integer seconds (nil when the header is missing or malformed — `Integer(value, exception: false)`). Raising via `.new` keeps the existing message argument intact, so `rescue => e; e.message` behavior is unchanged for current callers.