### PR TITLE
Add read/connection timeouts to the Faraday client

### DIFF
--- a/lib/help_scout/api/client.rb
+++ b/lib/help_scout/api/client.rb
@@ -31,7 +31,7 @@ module HelpScout
       def build_connection
         Faraday.new(url: BASE_URL) do |conn|
           conn.options.timeout = 30
-          conn.options.open_timeout = 10
+          conn.options.open_timeout = 30
           conn.request :json
           conn.response(:json, content_type: /\bjson$/)
           conn.adapter(Faraday.default_adapter)

--- a/lib/help_scout/api/client.rb
+++ b/lib/help_scout/api/client.rb
@@ -30,6 +30,8 @@ module HelpScout
 
       def build_connection
         Faraday.new(url: BASE_URL) do |conn|
+          conn.options.timeout = 30
+          conn.options.open_timeout = 10
           conn.request :json
           conn.response(:json, content_type: /\bjson$/)
           conn.adapter(Faraday.default_adapter)


### PR DESCRIPTION
The Faraday connection had no explicit timeouts, so a hung Help Scout endpoint or unreachable network could stall a request indefinitely (adapter defaults vary, and net/http's default read timeout is 60s with no open timeout guarantee).

Sets `timeout` and `open_timeout` to 30s on the connection. Generous enough for large list pages, bounded enough that callers with retry loops can make progress.