### PR TITLE
Fix 404 on folders path

### DIFF
--- a/lib/help_scout/folder.rb
+++ b/lib/help_scout/folder.rb
@@ -8,7 +8,7 @@ module HelpScout
       private
 
       def base_path
-        'mailboxes/%<MAILBOX_ID>/folders/'
+        'mailboxes/%<MAILBOX_ID>/folders'
       end
 
       def list_path(mailbox_id)

--- a/spec/cassettes/HelpScout_Folder/_list/returns_an_Array_of_HelpScout_Folder_objects.yml
+++ b/spec/cassettes/HelpScout_Folder/_list/returns_an_Array_of_HelpScout_Folder_objects.yml
@@ -43,7 +43,7 @@ http_interactions:
   recorded_at: Sun, 02 Jun 2019 13:47:15 GMT
 - request:
     method: get
-    uri: https://api.helpscout.net/v2/mailboxes/<TEST_MAILBOX_ID>/folders/
+    uri: https://api.helpscout.net/v2/mailboxes/<TEST_MAILBOX_ID>/folders
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/HelpScout_Mailbox/_folders/returns_an_Array_of_Folders.yml
+++ b/spec/cassettes/HelpScout_Mailbox/_folders/returns_an_Array_of_Folders.yml
@@ -97,7 +97,7 @@ http_interactions:
   recorded_at: Sun, 02 Jun 2019 13:47:35 GMT
 - request:
     method: get
-    uri: https://api.helpscout.net/v2/mailboxes/<TEST_MAILBOX_ID>/folders/
+    uri: https://api.helpscout.net/v2/mailboxes/<TEST_MAILBOX_ID>/folders
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/unit/folder_spec.rb
+++ b/spec/unit/folder_spec.rb
@@ -3,5 +3,5 @@
 require 'shared_examples/unit/listable'
 
 RSpec.describe HelpScout::Folder do
-  include_examples 'listable unit', "https://api.helpscout.net/v2/mailboxes/#{HelpScout.default_mailbox}/folders/"
+  include_examples 'listable unit', "https://api.helpscout.net/v2/mailboxes/#{HelpScout.default_mailbox}/folders"
 end

--- a/spec/unit/mailbox_spec.rb
+++ b/spec/unit/mailbox_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe HelpScout::Mailbox do
     let(:mailbox) { JSON.parse(file_fixture('mailbox/get.json')).deep_transform_keys { |k| k.underscore.to_sym } }
 
     before do
-      stub_request(:get, 'https://api.helpscout.net/v2/mailboxes/1/folders/')
+      stub_request(:get, 'https://api.helpscout.net/v2/mailboxes/1/folders')
         .to_return(body: body, headers: { 'Content-Type' => 'application/json' })
     end
 


### PR DESCRIPTION
The folders base path carried a trailing slash (`mailboxes/%<MAILBOX_ID>/folders/`), which the Help Scout API rejects with a 404. Dropping the slash fixes folder listing.